### PR TITLE
Fix cursor disappeared in terminal after script finished.

### DIFF
--- a/hls_get/downloader.py
+++ b/hls_get/downloader.py
@@ -129,5 +129,6 @@ class HLSDownloader:
                     )
                 tmp_list.dump(f'{self.cache_dir}/filelist.m3u8')
                 await asyncio.gather(*tasks)
+                bar.finish()
         else:
             click.echo('Live streaming media is not suppported!')


### PR DESCRIPTION
ShadyBar should call finish() method in the end.
BTW, useful tool, thank you.